### PR TITLE
Valid queen

### DIFF
--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,2 +1,16 @@
 class Queen < Piece
+  ### Created by Matt Arrick 9/26/19
+  def valid_move?(x, y)
+    # Queen can move any number of non obstructed horizontal, vertical, or diagonal spaces
+    # Check for obstructions and then test each directional movement
+    if is_obstructed(x, y) == true ||
+        diagonal_block(x, y) == true ||
+        x_pos != x ||
+        y_pos != y ||
+        (x_pos - x).abs != (y_pos - y).abs
+      false
+    else
+      true
+    end
+  end
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -2,12 +2,23 @@ class Queen < Piece
   ### Created by Matt Arrick 9/26/19
   def valid_move?(x, y)
     # Queen can move any number of non obstructed horizontal, vertical, or diagonal spaces
-    # Check for obstructions and then test each directional movement
-    if is_obstructed(x, y) == true ||
-        diagonal_block(x, y) == true ||
-        x_pos != x ||
-        y_pos != y ||
-        (x_pos - x).abs != (y_pos - y).abs
+    # Using the .abs method on each equation returns the absolute value which
+      # will simplfy the logic for forward or backward movements. Always subtract
+      # the starting position (x_pos, y_pos) from the ending position (x, y). Even if starting position
+      # is less than ending position, .abs will still return a positive number eliminating the 
+      # need for testing positive or negative movements
+
+    # Check for obstructions and then test move logic
+      # If "is_obstructed" OR "diagonal_block" is "true" OR
+        # horizontal ending point (x) does not equal horizontal starting point (x_pos) OR
+        # vertical ending point (y) does not equal vertical starting point (y_pos) OR
+        # not a diagonal move ((x_pos - x) does not equal (y_pos - y))
+        # then return false
+    if is_obstructed?(x, y) == true ||              # is_obstructed? test
+        diagonal_block?(x, y) == true ||            # diagonal_block? test
+        x_pos != x ||                               # horizontal test
+        y_pos != y ||                               # vertical test
+        (x_pos - x).abs != (y_pos - y).abs          # diagonal test
       false
     else
       true


### PR DESCRIPTION
Created valid_move? method for the queen. 

I'm using the **.abs** method for the slope equation.  **.abs** returns the absolute value of the equation.  As long as we always subtract the starting position (x_pos, y_pos) from the ending position (x, y) it will return a positive value and eliminate the need to check for both forward or backward movements.  For diagonal movements, the absolute value of (x_pos - x) MUST EQUAL the absolute value of (y_pos - y) in order to have slope, otherwise it is not a valid diagonal move.

With all this in mind the logic for queen isn't too difficult:
     It has to be on the same horizontal axis OR
     It has to be on the same vertical axis OR
     It has to be a valid diagonal move
THEREFORE
     IF (x_pos != x) OR 
           (y_pos != y) OR 
           (x_pos - x).abs != (y_pos - y).abs
     THEN it is not a valid move.